### PR TITLE
fix: dedupe animeId per user

### DIFF
--- a/AnilistConnector.js
+++ b/AnilistConnector.js
@@ -95,6 +95,7 @@ async function addUserListData(userId) {
 
     let sql = ""
     let recordCount = 0
+    let dedupe = new Map()
 
     const insertRecords = async () => {
         if (recordCount === 0) return
@@ -102,7 +103,7 @@ async function addUserListData(userId) {
         const sqlPrefix = "insert into GlobalAnimeRatings (userId, animeId, score) select t1.userId, t1.animeId, t1.score from (\n"
         const sqlSuffix = "\n" + ") t1 left join GlobalAnimeRatings t2\n"+
         "on t1.userId = t2.userId and t1.animeId = t2.animeId\n"+
-        "where t1.animeId is null"
+        "where t2.animeId is null"
 
         sql = sqlPrefix + sql + sqlSuffix
 
@@ -113,6 +114,9 @@ async function addUserListData(userId) {
     }
 
     const addRecord = async (entry) => {
+        if (dedupe.get(entry.media.id)) return
+        dedupe.set(entry.media.id, true)
+
         if (sql !== "") sql += "union "
         sql += `select ${userId} as userId, ${entry.media.id} as animeId, ${entry.score} as score\n`
 


### PR DESCRIPTION
- use Map to track animeId's already seen for user to prevent the
  same animeId from ending up in the generated SQL more than once
- fix table alias in where clause; found by @AllLuckBased

example of duplicate data returned by AniList GraphQL API:

```
$ curl -X POST https://graphql.anilist.co/ -H "Content-Type:
application/json" -H "Accept: application/json" -d
'{"query":"query($userId: Int) { MediaListCollection(userId: $userId,
type: ANIME) { lists { entries { media { id } score(format:
POINT_10_DECIMAL) } } } }","variables":{"userId":131527}}' | grep 103900
```

note: userId 131527 media.id 103900 is present in the response twice.
many other examples of duplicates exist.

further research may be needed to understand the reason for duplicate
entries. it may be worth looking at another example query in the AniList
repo to see if it also returns duplicates:

https://github.com/AniList/ApiV2-GraphQL-Docs/blob/master/migration/user-id-serieslist-raw.graphql